### PR TITLE
ERD Visualization overhaul and feature expansion

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,10 +26,6 @@ _schema_parser    = SchemaParser()
 # ─── DB connection helpers ───────────────────────────────────────────────────
 
 def _db_connect(db_type: str, schema: str = "", **kwargs) -> None:
-    """
-    Instantiate the right connector, connect, introspect, and store in
-    session state. Shows st.success or st.error inline.
-    """
     try:
         connector = get_connector(db_type)
         connector.connect(**kwargs)
@@ -46,7 +42,6 @@ def _db_connect(db_type: str, schema: str = "", **kwargs) -> None:
 
 
 def _db_disconnect() -> None:
-    """Close the active connector and clear all DB session state."""
     conn = st.session_state.get("db_conn")
     if conn is not None:
         try:
@@ -68,12 +63,10 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-# Force sidebar open — clears any persisted collapsed state in browser localStorage
 import streamlit.components.v1 as _components
 _components.html("""
 <script>
 (function() {
-  // Clear Streamlit's persisted sidebar state so it always starts expanded
   try {
     var keys = Object.keys(localStorage);
     keys.forEach(function(k) {
@@ -87,9 +80,6 @@ _components.html("""
 """, height=0)
 
 # ─── Inject CSS ──────────────────────────────────────────────────────────────
-# ── CSS: theme variables are generated from Python session state ─────────
-# This is the key insight: Streamlit re-runs this on every interaction,
-# so we just pick the right :root values directly — no JS needed at all.
 _DARK = dict(
     bg="#141e30", surface="#1a2640", card="#1e2d4a",
     border="#2a3f60", border2="#344f78",
@@ -153,28 +143,23 @@ html, body, [class*="css"] {{
   color: var(--text) !important;
 }}
 
-/* ── Background: all Streamlit containers use theme bg ── */
 .stApp, [data-testid="stAppViewContainer"],
 [data-testid="stMain"], [data-testid="stMainBlockContainer"],
 .block-container {{
   background: var(--bg) !important;
 }}
 
-/* ── Streamlit chrome ── */
 #MainMenu, footer {{ visibility: hidden; }}
 header {{ background: var(--surface) !important; border-bottom: 1px solid var(--border) !important; }}
 
-/* ── Layout ── */
 .block-container {{ padding: 1rem 2rem !important; max-width: 100% !important; }}
 section[data-testid="stSidebar"] {{
   background: var(--surface) !important;
   border-right: 1px solid var(--border) !important;
 }}
-/* Remove Streamlit's default top padding inside sidebar */
 section[data-testid="stSidebar"] > div:first-child {{
   padding-top: 0.5rem !important;
 }}
-/* Sidebar collapse/expand arrow — always accent colored */
 [data-testid="stSidebarCollapseButton"] button,
 [data-testid="stSidebarCollapsedControl"] button {{
   color: var(--bg) !important;
@@ -194,7 +179,6 @@ section[data-testid="stSidebar"] > div:first-child {{
   fill: currentColor !important;
 }}
 
-/* ── Theme toggle button ────────────────────────── */
 #theme-toggle-btn {{
   display: flex; align-items: center; gap: 8px;
   background: var(--card); border: 1px solid var(--border);
@@ -215,7 +199,6 @@ section[data-testid="stSidebar"] > div:first-child {{
   box-shadow: 0 1px 3px rgba(0,0,0,0.3);
 }}
 
-/* ── Sidebar labels ─────────────────────────────── */
 .sidebar-section {{
   font-family: var(--mono); font-size: 10px; font-weight: 700;
   letter-spacing: 2.5px; text-transform: uppercase;
@@ -224,7 +207,6 @@ section[data-testid="stSidebar"] > div:first-child {{
 }}
 .sidebar-hint {{ font-size: 12px; color: var(--text3); margin: -4px 0 10px; line-height: 1.6; font-family: var(--sans); }}
 
-/* ── Pills ──────────────────────────────────────── */
 .pill {{
   display: inline-block; padding: 2px 9px; border-radius: 20px;
   font-size: 11px; font-family: var(--mono); margin: 2px;
@@ -237,7 +219,6 @@ section[data-testid="stSidebar"] > div:first-child {{
 .p-warn  {{ background: rgba(242,107,122,0.12);color: var(--red);    border-color: rgba(242,107,122,0.28); }}
 .p-schema{{ background: rgba(245,146,78,0.10); color: var(--orange); border-color: rgba(245,146,78,0.25); }}
 
-/* ── Table cards ────────────────────────────────── */
 .tbl-card {{
   background: var(--card); border: 1px solid var(--border);
   border-radius: 10px; padding: 18px; margin-bottom: 16px;
@@ -254,7 +235,6 @@ section[data-testid="stSidebar"] > div:first-child {{
   border: 1px solid rgba(245,146,78,0.22);
 }}
 
-/* ── Relationship rows ──────────────────────────── */
 .rel-row {{
   display: flex; align-items: center; gap: 8px;
   padding: 9px 14px; margin: 4px 0;
@@ -283,7 +263,6 @@ section[data-testid="stSidebar"] > div:first-child {{
 .m-schema         {{ background: rgba(77,166,255,0.12); color: var(--sig-schema); border-color: rgba(77,166,255,0.25); }}
 .m-content        {{ background: rgba(167,139,250,0.12);color: var(--sig-fmt);    border-color: rgba(167,139,250,0.25); }}
 
-/* Confidence bar */
 .conf-bar {{ display:flex; align-items:center; gap:6px; margin-left:auto; }}
 .conf-dot {{ width:8px; height:8px; border-radius:50%; flex-shrink:0; }}
 .conf-high   .conf-dot {{ background: var(--green); }}
@@ -295,32 +274,27 @@ section[data-testid="stSidebar"] > div:first-child {{
 .conf-low    .conf-label {{ color: var(--text3); }}
 .conf-score {{ font-size:10px; color: var(--text3); font-family:var(--sans); }}
 
-/* Signal chips */
 .signal-chips {{ display:flex; flex-wrap:wrap; gap:3px; margin-top:4px; padding-left:4px; }}
 .sig-chip {{
   font-size:9px; font-family:var(--mono); padding:1px 7px; border-radius:8px;
   background: var(--card); border: 1px solid var(--border); color: var(--text3);
 }}
 
-/* ── Section headers ────────────────────────────── */
 .rel-section {{
   font-family: var(--sans); font-size: 11px; font-weight: 600; letter-spacing: 1.5px;
   text-transform: uppercase; color: var(--text3);
   padding: 14px 0 6px;
 }}
 
-/* ── ERD hint ───────────────────────────────────── */
 .erd-hint {{
   font-size: 11px; color: var(--text3); text-align: center;
   padding: 8px; font-family: var(--sans); letter-spacing: 0.2px;
 }}
 
-/* ── Legend ─────────────────────────────────────── */
 .legend {{ display: flex; gap: 20px; padding: 10px 0 14px; flex-wrap: wrap; }}
 .li {{ display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text2); font-family: var(--mono); }}
 .ld {{ width: 10px; height: 10px; border-radius: 50%; }}
 
-/* ── Loaded tables list ─────────────────────────── */
 .tbl-item {{
   display: flex; align-items: center; justify-content: space-between;
   padding: 6px 10px; margin: 3px 0;
@@ -330,7 +304,6 @@ section[data-testid="stSidebar"] > div:first-child {{
 .tbl-item .tn {{ font-family: var(--mono); font-size: 11px; color: var(--text); }}
 .tbl-item .tm {{ font-size: 10px; color: var(--text3); font-family: var(--mono); }}
 
-/* ── Empty state ────────────────────────────────── */
 .empty-state {{
   text-align: center; padding: 80px 40px;
   color: var(--text3); font-family: var(--sans);
@@ -338,7 +311,6 @@ section[data-testid="stSidebar"] > div:first-child {{
 .empty-state .icon {{ font-size: 48px; margin-bottom: 16px; }}
 .empty-state h3 {{ color: var(--text2); font-size: 18px; font-weight: 600; margin-bottom: 8px; font-family: var(--sans); }}
 
-/* ── Streamlit overrides ────────────────────────── */
 .stTabs [data-baseweb="tab-list"] {{
   background: transparent !important;
   border-bottom: 1px solid var(--border) !important;
@@ -368,15 +340,13 @@ section[data-testid="stSidebar"] > div:first-child {{
   color: var(--text) !important;
   border-radius: 6px !important;
 }}
-/* ── Comprehensive Streamlit widget overrides ── */
 
-/* File uploader */
 .stFileUploader {{
   background: var(--card) !important;
   border: 1px solid var(--border) !important;
   border-radius: 10px !important;
 }}
-.stFileUploader label, 
+.stFileUploader label,
 .stFileUploader span,
 .stFileUploader p,
 .stFileUploader small,
@@ -409,7 +379,6 @@ section[data-testid="stSidebar"] > div:first-child {{
   border-radius: 6px !important;
 }}
 
-/* All buttons */
 .stButton > button,
 button[kind="secondary"],
 button[kind="primary"] {{
@@ -435,7 +404,6 @@ button[kind="primary"] {{
   border-color: var(--accent) !important;
 }}
 
-/* Labels / text everywhere */
 label, .stSelectbox label, .stCheckbox label,
 [data-testid="stWidgetLabel"] span,
 [data-testid="stWidgetLabel"] p {{
@@ -444,7 +412,6 @@ label, .stSelectbox label, .stCheckbox label,
   font-size: 13px !important;
 }}
 
-/* Selectbox */
 .stSelectbox > div > div {{
   background: var(--card) !important;
   border: 1px solid var(--border2) !important;
@@ -453,13 +420,11 @@ label, .stSelectbox label, .stCheckbox label,
   font-family: var(--sans) !important;
 }}
 
-/* Checkboxes */
 .stCheckbox span {{
   font-family: var(--sans) !important;
   color: var(--text) !important;
 }}
 
-/* Expanders */
 [data-testid="stExpander"] {{
   background: var(--card) !important;
   border: 1px solid var(--border) !important;
@@ -469,14 +434,26 @@ label, .stSelectbox label, .stCheckbox label,
   font-family: var(--sans) !important;
   color: var(--text2) !important;
 }}
+/* Hide spurious arrow_right icon text Streamlit renders in expander headers */
+[data-testid="stExpander"] summary svg ~ span:first-of-type {{
+  display: none !important;
+}}
+[data-testid="stExpander"] details summary p {{
+  font-family: var(--sans) !important;
+  font-size: 13px !important;
+  color: var(--text2) !important;
+}}
+/* Target the material icon span that renders as text */
+[data-testid="stExpander"] summary .st-emotion-cache-1clstc5,
+[data-testid="stExpander"] summary [data-testid="stExpanderToggleIcon"] {{
+  font-size: 0 !important;
+}}
 
-/* Select slider */
 .stSlider label, .stSlider span {{
   font-family: var(--sans) !important;
   color: var(--text2) !important;
 }}
 
-/* Success / info / warning banners */
 .stAlert {{
   background: var(--card) !important;
   border-color: var(--border2) !important;
@@ -484,19 +461,16 @@ label, .stSelectbox label, .stCheckbox label,
   font-family: var(--sans) !important;
 }}
 
-/* Dataframe */
 div[data-testid="stDataFrame"] {{
   background: var(--card) !important;
   border-radius: 8px !important;
 }}
 
-/* Spinner text */
 .stSpinner p {{
   font-family: var(--sans) !important;
   color: var(--text2) !important;
 }}
 
-/* File list items in uploader */
 [data-testid="stFileUploaderFile"] {{
   background: var(--surface) !important;
   border: 1px solid var(--border) !important;
@@ -508,7 +482,6 @@ div[data-testid="stDataFrame"] {{
   color: var(--text2) !important;
 }}
 
-/* Page navigation */
 [data-testid="stFileUploaderFileListSection"] small {{
   font-family: var(--sans) !important;
   color: var(--text3) !important;
@@ -520,7 +493,7 @@ div[data-testid="stDataFrame"] {{
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Inference helpers (wrappers around SchemaInferenceEngine)
+# Inference helpers
 # ═══════════════════════════════════════════════════════════════════════════
 
 def detect_pks(df: pd.DataFrame, table_name: str, method: str = "both") -> list[str]:
@@ -548,11 +521,21 @@ def parse_schema_yaml(raw: str):
 # Network / Graph builder (pyvis via networkx)
 # ═══════════════════════════════════════════════════════════════════════════
 
-def build_pyvis_html(tables: dict, rels: list[dict], pk_map: dict, spring_length: int = 220, dark_mode: bool = True) -> str:
+def build_pyvis_html(
+    tables: dict,
+    rels: list[dict],
+    pk_map: dict,
+    spring_length: int = 220,
+    dark_mode: bool = True,
+    saved_positions: dict | None = None,
+    layout: str = "force",
+    search: str = "",
+) -> str:
     """
-    Render an interactive vis.js network and return the HTML string.
-    Tooltips are injected via a custom overlay div driven by JS to avoid
-    pyvis escaping the HTML in the title attribute.
+    Render an interactive vis.js ERD and return an HTML string.
+    Includes: column nodes, cardinality notation, hidden edge labels,
+    confidence opacity+width, source cluster bubbles, minimap, focus mode,
+    PNG export, layout presets, table search highlight, position persistence.
     """
     from pyvis.network import Network
 
@@ -567,11 +550,10 @@ def build_pyvis_html(tables: dict, rels: list[dict], pk_map: dict, spring_length
     _muted   = "#9ab0cc" if dark_mode else "#475569"
     _dim     = "#5a7898" if dark_mode else "#94a3b8"
     _yellow  = "#fbbf24" if dark_mode else "#854d0e"
+    _green   = "#4ade80" if dark_mode else "#166534"
 
-    net = Network(height="560px", width="100%", bgcolor=_bg, font_color=_fg,
-                  directed=True, notebook=False)
-    net.force_atlas_2based(gravity=-60, central_gravity=0.005, spring_length=spring_length,
-                            spring_strength=0.04, damping=0.9)
+    saved_positions = saved_positions or {}
+    search_lower    = search.strip().lower()
 
     method_colors = {
         "schema":          "#5badff",
@@ -585,108 +567,168 @@ def build_pyvis_html(tables: dict, rels: list[dict], pk_map: dict, spring_length
         "manual":          "#f87171",
         "content":         "#c084fc",
     }
+    # confidence → (opacity, width)
+    conf_style = {"high": (0.95, 2.5), "medium": (0.60, 1.5), "low": (0.28, 0.8), "": (0.90, 2.0)}
 
-    # Build tooltip HTML strings stored in a JS dict — bypasses pyvis title escaping
+    net = Network(height="620px", width="100%", bgcolor=_bg, font_color=_fg,
+                  directed=True, notebook=False)
+
+    if layout == "hierarchical":
+        net.set_options("""{"layout":{"hierarchical":{"enabled":true,"direction":"UD",
+          "sortMethod":"directed","levelSeparation":180,"nodeSpacing":160}},
+          "physics":{"enabled":false},
+          "interaction":{"hover":true,"tooltipDelay":80,"navigationButtons":true,"hideEdgesOnDrag":false}}""")
+    elif layout == "circular":
+        import math as _math
+        n  = max(len(tables), 1)
+        rr = max(300, n * 90)
+        for idx, tname in enumerate(tables):
+            if tname not in saved_positions:
+                angle = 2 * _math.pi * idx / n
+                saved_positions[tname] = {"x": rr * _math.cos(angle), "y": rr * _math.sin(angle), "fixed": True}
+        net.set_options("""{"layout":{"randomSeed":42},"physics":{"enabled":false},
+          "interaction":{"hover":true,"tooltipDelay":80,"navigationButtons":true,"hideEdgesOnDrag":false}}""")
+    else:
+        net.force_atlas_2based(gravity=-60, central_gravity=0.005,
+                               spring_length=spring_length, spring_strength=0.04, damping=0.9)
+        net.set_options("""{"interaction":{"hover":true,"tooltipDelay":80,"navigationButtons":true,
+          "hideEdgesOnDrag":false},"physics":{"enabled":true,"stabilization":{"iterations":300}},
+          "layout":{"randomSeed":42},"edges":{"smooth":{"type":"curvedCW","roundness":0.15}}}""")
+
     node_tooltips = {}
     edge_tooltips = {}
 
-    for tname, df in tables.items():
-        pks = pk_map.get(tname, [])
-        fk_rels = [r for r in rels if r["from_table"] == tname]
-        fk_str = "<br>".join(f"{r['from_col']} → {r['to_table']}" for r in fk_rels) or "none"
-        pk_str = ", ".join(pks) if pks else "none detected"
-        src = df.attrs.get("source", "csv")
-        row_str = f"{len(df):,}" if len(df) > 0 else "schema"
+    # FK cols per table
+    fk_col_map: dict[str, set] = {t: set() for t in tables}
+    for r in rels:
+        fk_col_map.setdefault(r["from_table"], set()).add(r["from_col"])
 
+    # Source groups
+    source_groups: dict[str, list] = {}
+    for tname, df in tables.items():
+        s = df.attrs.get("source", "csv")
+        source_groups.setdefault(s, []).append(tname)
+    src_colors_list = [
+        "rgba(91,173,255,0.07)", "rgba(74,222,128,0.07)", "rgba(192,132,252,0.07)",
+        "rgba(251,191,36,0.07)", "rgba(251,146,60,0.07)",  "rgba(241,107,122,0.07)",
+    ]
+    src_color_map = {s: src_colors_list[i % len(src_colors_list)] for i, s in enumerate(source_groups)}
+
+    matched = {t for t in tables if search_lower and search_lower in t.lower()}
+
+    for tname, df in tables.items():
+        pks       = pk_map.get(tname, [])
+        fk_cols   = fk_col_map.get(tname, set())
+        src_tag   = df.attrs.get("source", "csv")
+        row_str   = f"{len(df):,}" if len(df) > 0 else "schema"
+        sampled   = df.attrs.get("sampled", False)
+
+        MAX_COLS  = 12
+        cols      = list(df.columns)
+        col_lines = []
+        for c in cols[:MAX_COLS]:
+            icon = "\U0001f511" if c in pks else ("\u2197" if c in fk_cols else "\u00b7")
+            col_lines.append(f"{icon} {c}")
+        if len(cols) > MAX_COLS:
+            col_lines.append(f"  \u2026 +{len(cols) - MAX_COLS} more")
+        sep   = "\u2500" * max(len(tname), 14)
+        label = f"{tname}\n{sep}\n" + "\n".join(col_lines)
+
+        col_rows = "".join(
+            f"<div style='padding:1px 0;'>"
+            f"<span style='color:{'#fbbf24' if c in pks else ('#c084fc' if c in fk_cols else _muted)};'>"
+            f"{'PK' if c in pks else ('FK' if c in fk_cols else '\u00a0\u00a0')}</span>"
+            f"&nbsp;<span style='color:{_fg};'>{c}</span></div>"
+            for c in cols
+        )
+        samp_note = f"<div style='color:{_yellow};font-size:9px;margin-top:3px;'>\u26a1 sampled for analysis</div>" if sampled else ""
         node_tooltips[tname] = (
             f"<div style='color:#5badff;font-size:13px;font-weight:700;margin-bottom:8px;'>{tname}</div>"
-            f"<span style='color:#4ade80;'>■ {row_str} rows</span>&nbsp;&nbsp;"
-            f"<span style='color:#5badff;'>■ {len(df.columns)} cols</span><br>"
+            f"<span style='color:{_green};'>\u25a0 {row_str} rows</span>&nbsp;&nbsp;"
+            f"<span style='color:#5badff;'>\u25a0 {len(cols)} cols</span>{samp_note}<br>"
             f"<div style='border-top:1px solid #243b58;margin:8px 0 4px;padding-top:6px;'>"
-            f"<span style='color:{_muted};font-size:9px;letter-spacing:1px;'>PRIMARY KEY</span><br>"
-            f"<span style='color:{_yellow};'>{pk_str}</span></div>"
-            f"<div style='border-top:1px solid #243b58;margin:8px 0 4px;padding-top:6px;'>"
-            f"<span style='color:{_muted};font-size:9px;letter-spacing:1px;'>FOREIGN KEYS</span><br>"
-            f"<span style='color:#c084fc;'>{fk_str}</span></div>"
+            f"<span style='color:{_muted};font-size:9px;letter-spacing:1px;'>COLUMNS</span>"
+            f"<div style='margin-top:4px;max-height:180px;overflow-y:auto;'>{col_rows}</div></div>"
             f"<div style='border-top:1px solid #243b58;margin:8px 0 0;padding-top:6px;'>"
-            f"<span style='color:{_muted};font-size:9px;letter-spacing:1px;'>SOURCE: {src.upper()}</span></div>"
+            f"<span style='color:{_muted};font-size:9px;letter-spacing:1px;'>SOURCE: {src_tag.upper()}</span></div>"
         )
 
-        label = f"{tname}\n{row_str} rows | {len(df.columns)} cols"
-        # title=" " — single space so pyvis doesn't strip the title attr,
-        # but blank enough that nothing shows if our overlay fails
-        net.add_node(tname, label=label, title=" ",
-                     color={"background": _node_bg, "border": _node_bd,
-                            "highlight": {"background": _node_hi, "border": _node_hb}},
-                     font={"color": _fg, "size": 13, "face": "JetBrains Mono"},
-                     shape="box", shadow=True, widthConstraint={"minimum": 140, "maximum": 220})
+        is_dimmed  = bool(matched and tname not in matched)
+        is_matched = bool(matched and tname in matched)
+        border_col = {"background": _node_bg, "border": "#fbbf24" if is_matched else _node_bd,
+                      "highlight": {"background": _node_hi, "border": "#fbbf24" if is_matched else _node_hb}}
+
+        saved = saved_positions.get(tname, {})
+        node_kw = dict(
+            label=label, title=" ", color=border_col,
+            font={"color": _fg, "size": 11, "face": "JetBrains Mono", "multi": False},
+            shape="box", shadow=True,
+            widthConstraint={"minimum": 160, "maximum": 240},
+            margin={"top": 10, "right": 12, "bottom": 10, "left": 12},
+            opacity=0.25 if is_dimmed else 1.0,
+        )
+        if saved:
+            node_kw["x"] = saved["x"]
+            node_kw["y"] = saved["y"]
+            node_kw["physics"] = not saved.get("fixed", False)
+        net.add_node(tname, **node_kw)
 
     for i, r in enumerate(rels):
-        ecol = method_colors.get(r["detected_by"], "#00d4ff")
-        to_col = r.get("to_col") or "?"
+        ecol    = method_colors.get(r["detected_by"], "#00d4ff")
+        to_col  = r.get("to_col") or "?"
         edge_id = f"e{i}"
-        conf     = r.get("confidence", "")
-        score    = r.get("score", "")
-        reasons  = r.get("reasons", [])
-        score_str = f" · {score:.0%}" if isinstance(score, float) else ""
-        conf_str  = f"<br><span style='color:{_muted};font-size:9px;'>confidence: {conf}{score_str}</span>" if conf else ""
-        reasons_str = ""
-        if reasons:
-            rlist = " · ".join(reasons[:4])
-            reasons_str = f"<br><span style='color:{_muted};font-size:9px;'>{rlist}</span>"
+        conf    = r.get("confidence", "")
+        score   = r.get("score", "")
+        reasons = r.get("reasons", [])
+
+        opacity, width = conf_style.get(conf, (0.90, 2.0))
+        score_str   = f" \u00b7 {score:.0%}" if isinstance(score, float) else ""
+        conf_str    = f"<br><span style='color:{_muted};font-size:9px;'>confidence: {conf}{score_str}</span>" if conf else ""
+        reasons_str = (f"<br><span style='color:{_muted};font-size:9px;'>"
+                       f"{' \u00b7 '.join(reasons[:4])}</span>") if reasons else ""
+
         edge_tooltips[edge_id] = (
             f"<span style='color:{_muted};'>{r['from_table']}.</span>"
             f"<span style='color:{_yellow};font-weight:700;'>{r['from_col']}</span>"
-            f"<span style='color:{_dim};'> → </span>"
+            f"<span style='color:{_dim};'> \u2192 </span>"
             f"<span style='color:{_muted};'>{r['to_table']}.</span>"
             f"<span style='color:{_yellow};font-weight:700;'>{to_col}</span><br>"
-            f"<span style='color:{ecol};font-size:9px;letter-spacing:1px;'>■ {r['detected_by'].replace('_',' ').upper()}</span>"
+            f"<span style='color:{ecol};font-size:9px;letter-spacing:1px;'>\u25a0 {r['detected_by'].replace('_',' ').upper()}</span>"
             f"{conf_str}{reasons_str}"
         )
-        net.add_edge(r["from_table"], r["to_table"],
-                     label=r["from_col"], title=" ",
-                     id=edge_id,
-                     color={"color": ecol, "highlight": ecol, "opacity": 0.85},
-                     arrows="to", dashes=(r["detected_by"] in ("value_overlap","distribution","null_pattern","format")),
-                     font={"color": "#cdd9e8", "size": 10, "face": "JetBrains Mono",
-                           "strokeWidth": 3, "strokeColor": "#070d16"})
 
-    net.set_options("""
-    {
-      "interaction": {"hover": true, "tooltipDelay": 80, "navigationButtons": true, "hideEdgesOnDrag": false},
-      "physics": {"enabled": true, "stabilization": {"iterations": 300}},
-      "layout": {"randomSeed": 42}
-    }
-    """)
+        is_dashed = r["detected_by"] in ("value_overlap", "distribution", "null_pattern", "format")
+        net.add_edge(
+            r["from_table"], r["to_table"],
+            label="", title=" ", id=edge_id,
+            color={"color": ecol, "highlight": ecol, "opacity": opacity},
+            width=width,
+            arrows={"to": {"enabled": True, "type": "arrow", "scaleFactor": 0.8},
+                    "from": {"enabled": True, "type": "bar", "scaleFactor": 0.4}},
+            dashes=is_dashed,
+            font={"color": ecol, "size": 9, "face": "JetBrains Mono",
+                  "strokeWidth": 2, "strokeColor": _bg, "align": "middle"},
+            smooth={"type": "curvedCW", "roundness": 0.15},
+        )
 
     raw_html = net.generate_html(notebook=False)
 
-    # ── Inject custom tooltip overlay + JS ───────────────────────────────
-    node_tips_js = json.dumps(node_tooltips)
-    edge_tips_js = json.dumps(edge_tooltips)
+    node_tips_js  = json.dumps(node_tooltips)
+    edge_tips_js  = json.dumps(edge_tooltips)
+    saved_pos_js  = json.dumps(saved_positions)
+    src_nodes_js  = json.dumps({s: ns for s, ns in source_groups.items() if len(source_groups) > 1})
+    src_colors_js = json.dumps(src_color_map)
 
     custom_js = f"""
 <style>
-/* ── vis.js navigation button overrides ── */
 div.vis-network div.vis-navigation div.vis-button {{
-  background-color: {_node_bg} !important;
-  border: 1px solid {_node_bd} !important;
-  border-radius: 6px !important;
-  opacity: 0.85;
-  filter: none !important;
-  width: 28px !important;
-  height: 28px !important;
+  background-color: {_node_bg} !important; border: 1px solid {_node_bd} !important;
+  border-radius: 6px !important; opacity: 0.85; filter: none !important;
+  width: 28px !important; height: 28px !important;
 }}
 div.vis-network div.vis-navigation div.vis-button:hover {{
-  background-color: {_node_hi} !important;
-  border-color: {_node_hb} !important;
-  opacity: 1;
+  background-color: {_node_hi} !important; border-color: {_node_hb} !important; opacity: 1;
 }}
-div.vis-network div.vis-navigation div.vis-button .vis-label {{
-  color: {_fg} !important;
-  font-size: 14px !important;
-}}
-/* Override the default vis.js green background-image icons with CSS-drawn ones */
 div.vis-network div.vis-navigation div.vis-button.vis-up,
 div.vis-network div.vis-navigation div.vis-button.vis-down,
 div.vis-network div.vis-navigation div.vis-button.vis-left,
@@ -694,13 +736,9 @@ div.vis-network div.vis-navigation div.vis-button.vis-right,
 div.vis-network div.vis-navigation div.vis-button.vis-zoomIn,
 div.vis-network div.vis-navigation div.vis-button.vis-zoomOut,
 div.vis-network div.vis-navigation div.vis-button.vis-zoomExtends {{
-  background-image: none !important;
-  display: flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  color: {_fg} !important;
-  font-size: 16px !important;
-  font-weight: 600 !important;
+  background-image: none !important; display: flex !important;
+  align-items: center !important; justify-content: center !important;
+  color: {_fg} !important; font-size: 16px !important; font-weight: 600 !important;
 }}
 div.vis-network div.vis-navigation div.vis-button.vis-up::after    {{ content: "↑"; }}
 div.vis-network div.vis-navigation div.vis-button.vis-down::after  {{ content: "↓"; }}
@@ -709,136 +747,214 @@ div.vis-network div.vis-navigation div.vis-button.vis-right::after {{ content: "
 div.vis-network div.vis-navigation div.vis-button.vis-zoomIn::after      {{ content: "+"; }}
 div.vis-network div.vis-navigation div.vis-button.vis-zoomOut::after     {{ content: "−"; }}
 div.vis-network div.vis-navigation div.vis-button.vis-zoomExtends::after {{ content: "⊡"; }}
-
+#erd-toolbar {{
+  position: absolute; top: 8px; right: 8px; z-index: 100; display: flex; gap: 6px;
+}}
+.erd-btn {{
+  background: {_node_bg}; border: 1px solid {_node_bd}; color: {_fg};
+  font-family: 'JetBrains Mono', monospace; font-size: 10px; padding: 4px 10px;
+  border-radius: 5px; cursor: pointer; transition: all 0.15s;
+  user-select: none; letter-spacing: 0.5px;
+}}
+.erd-btn:hover  {{ border-color: {_node_hb}; color: {_node_hb}; }}
+.erd-btn.active {{ background: {_node_hb}; color: {_bg}; border-color: {_node_hb}; }}
+#minimap {{
+  position: absolute; bottom: 40px; right: 8px; width: 140px; height: 90px;
+  background: {_node_bg}; border: 1px solid {_node_bd}; border-radius: 6px;
+  overflow: hidden; z-index: 50; opacity: 0.85;
+}}
+#minimap canvas {{ width: 100% !important; height: 100% !important; }}
 #custom-tooltip {{
-  position: fixed;
-  z-index: 9999;
-  background: {_tip_bg};
-  color: {_fg};
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  padding: 14px 16px;
-  min-width: 210px;
-  max-width: 320px;
-  border: 1px solid {_tip_bd};
-  border-radius: 8px;
-  line-height: 1.8;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
-  pointer-events: none;
-  display: none;
+  position: fixed; z-index: 9999; background: {_tip_bg}; color: {_fg};
+  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  padding: 14px 16px; min-width: 210px; max-width: 320px;
+  border: 1px solid {_tip_bd}; border-radius: 8px; line-height: 1.8;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4); pointer-events: none; display: none;
 }}
 </style>
+<div id="erd-toolbar">
+  <button class="erd-btn" id="btn-focus">Focus</button>
+  <button class="erd-btn" id="btn-minimap">Map</button>
+  <button class="erd-btn" id="btn-png">PNG ↓</button>
+</div>
+<div id="minimap" style="display:none;"></div>
 <div id="custom-tooltip"></div>
 <script>
 (function() {{
-  var nodeTips = {node_tips_js};
-  var edgeTips = {edge_tips_js};
-  var tip = document.getElementById('custom-tooltip');
+  var nodeTips   = {node_tips_js};
+  var edgeTips   = {edge_tips_js};
+  var savedPos   = {saved_pos_js};
+  var srcNodes   = {src_nodes_js};
+  var srcColors  = {src_colors_js};
+  var tip        = document.getElementById('custom-tooltip');
+  var minimapEl  = document.getElementById('minimap');
+  var btnFocus   = document.getElementById('btn-focus');
+  var btnMinimap = document.getElementById('btn-minimap');
+  var btnPng     = document.getElementById('btn-png');
+  var focusMode = false, focusedNode = null, minimapOn = false, minimapNet = null, dragging = false;
 
   function showTip(html, x, y) {{
-    tip.innerHTML = html;
-    tip.style.display = 'block';
-    // Keep tooltip inside viewport
-    var vw = window.innerWidth, vh = window.innerHeight;
-    var tw = 240, th = tip.offsetHeight || 180;
-    var left = x + 16;
-    var top  = y + 16;
+    tip.innerHTML = html; tip.style.display = 'block';
+    var vw = window.innerWidth, vh = window.innerHeight, tw = 240, th = tip.offsetHeight || 180;
+    var left = x + 16, top = y + 16;
     if (left + tw > vw) left = x - tw - 8;
     if (top  + th > vh) top  = y - th - 8;
-    tip.style.left = left + 'px';
-    tip.style.top  = top  + 'px';
+    tip.style.left = left + 'px'; tip.style.top = top + 'px';
   }}
+  function hideTip() {{ tip.style.display = 'none'; }}
 
-  function hideTip() {{
-    tip.style.display = 'none';
-  }}
-
-  // Poll until vis network is available then bind events
   var attempts = 0;
   var poll = setInterval(function() {{
-    attempts++;
-    if (attempts > 100) {{ clearInterval(poll); return; }}
+    if (++attempts > 150) {{ clearInterval(poll); return; }}
     var canvas = document.querySelector('canvas');
     if (!canvas) return;
-    // Find the vis Network instance on the window
     var net = null;
     for (var k in window) {{
-      try {{
-        if (window[k] && window[k].body && window[k].body.nodes) {{
-          net = window[k]; break;
-        }}
-      }} catch(e) {{}}
+      try {{ if (window[k] && window[k].body && window[k].body.nodes) {{ net = window[k]; break; }} }}
+      catch(e) {{}}
     }}
     if (!net) return;
     clearInterval(poll);
 
-    // ── Pin node in place after drag ──────────────────────────────────
-    // When the user drops a node, fix its x/y so the physics engine
-    // stops pulling it back toward the cluster.
-    var dragging = false;
-
-    net.on('dragStart', function(params) {{
-      if (params.nodes.length > 0) {{
-        dragging = true;
-        hideTip();
+    // Restore saved positions
+    if (Object.keys(savedPos).length > 0) {{
+      var upd = [];
+      for (var nid in savedPos) {{
+        var p = savedPos[nid];
+        upd.push({{ id: nid, x: p.x, y: p.y, fixed: {{ x: true, y: true }} }});
       }}
-    }});
+      net.body.data.nodes.update(upd);
+    }}
 
-    net.on('dragEnd', function(params) {{
-      dragging = false;
-      if (params.nodes.length > 0) {{
-        var nodeId = params.nodes[0];
-        var pos = net.getPositions([nodeId])[nodeId];
-        // Fix the node at its dropped position — physics won't move it again
-        net.body.data.nodes.update({{
-          id: nodeId,
-          x: pos.x,
-          y: pos.y,
-          fixed: {{ x: true, y: true }}
+    // Source cluster overlay
+    var container = canvas.parentElement;
+    container.style.position = 'relative';
+    var ov = document.createElement('canvas');
+    ov.style.cssText = 'position:absolute;top:0;left:0;pointer-events:none;z-index:0;';
+    ov.width = canvas.offsetWidth || 800; ov.height = canvas.offsetHeight || 600;
+    container.insertBefore(ov, canvas);
+    canvas.style.position = 'relative'; canvas.style.zIndex = '1';
+
+    function drawClusters() {{
+      var ctx = ov.getContext('2d');
+      ov.width = canvas.offsetWidth || 800; ov.height = canvas.offsetHeight || 600;
+      ctx.clearRect(0, 0, ov.width, ov.height);
+      for (var src in srcNodes) {{
+        var nodes = srcNodes[src];
+        if (!nodes || nodes.length < 2) continue;
+        var pos = net.getPositions(nodes), xs = [], ys = [];
+        for (var nid in pos) {{
+          var dp = net.canvasToDOM(pos[nid]); xs.push(dp.x); ys.push(dp.y);
+        }}
+        if (!xs.length) continue;
+        var minX = Math.min.apply(null,xs)-40, maxX = Math.max.apply(null,xs)+40;
+        var minY = Math.min.apply(null,ys)-40, maxY = Math.max.apply(null,ys)+40;
+        var cx = (minX+maxX)/2, cy = (minY+maxY)/2, rx = (maxX-minX)/2, ry = (maxY-minY)/2;
+        ctx.save(); ctx.beginPath(); ctx.ellipse(cx,cy,rx,ry,0,0,Math.PI*2);
+        ctx.fillStyle = srcColors[src] || 'rgba(255,255,255,0.05)';
+        ctx.strokeStyle = (srcColors[src]||'rgba(255,255,255,0.12)').replace('0.07','0.18');
+        ctx.lineWidth = 1; ctx.fill(); ctx.stroke(); ctx.restore();
+        ctx.save(); ctx.font = '9px JetBrains Mono,monospace';
+        ctx.fillStyle = '{_muted}'; ctx.globalAlpha = 0.7;
+        ctx.fillText(src.toUpperCase(), minX+6, minY+14); ctx.restore();
+      }}
+    }}
+    net.on('afterDrawing', drawClusters);
+    net.on('zoom', drawClusters);
+    net.on('dragEnd', drawClusters);
+
+    // Drag + pin
+    net.on('dragStart', function(p) {{ if (p.nodes.length>0) {{ dragging=true; hideTip(); }} }});
+    net.on('dragEnd', function(p) {{
+      dragging = false; drawClusters();
+      if (p.nodes.length > 0) {{
+        var nid = p.nodes[0], pos = net.getPositions([nid])[nid];
+        net.body.data.nodes.update({{ id:nid, x:pos.x, y:pos.y, fixed:{{x:true,y:true}} }});
+        var allPos = net.getPositions(), fixedIds = {{}}, payload = {{}};
+        net.body.data.nodes.getIds().forEach(function(id) {{
+          var n = net.body.data.nodes.get(id); if (n&&n.fixed&&n.fixed.x) fixedIds[id]=true;
         }});
+        for (var id in allPos) payload[id] = {{x:allPos[id].x,y:allPos[id].y,fixed:!!fixedIds[id]}};
+        window.parent.postMessage({{type:'cartographer_positions',positions:payload}},'*');
       }}
     }});
 
-    // Double-click a node to unpin it (release back into physics)
-    net.on('doubleClick', function(params) {{
-      if (params.nodes.length > 0) {{
-        var nodeId = params.nodes[0];
-        net.body.data.nodes.update({{
-          id: nodeId,
-          fixed: {{ x: false, y: false }}
+    // Double-click to unpin
+    net.on('doubleClick', function(p) {{
+      if (p.nodes.length > 0) {{
+        net.body.data.nodes.update({{id:p.nodes[0],fixed:{{x:false,y:false}}}});
+        if (focusMode && focusedNode===p.nodes[0]) clearFocus();
+      }}
+    }});
+
+    // Focus mode
+    function applyFocus(nid) {{
+      focusedNode = nid;
+      var ce = net.getConnectedEdges(nid), cn = net.getConnectedNodes(nid);
+      cn.push(nid);
+      net.body.data.nodes.update(net.body.data.nodes.getIds().map(function(id) {{
+        return {{id:id, opacity: cn.indexOf(id)>=0 ? 1.0 : 0.1}};
+      }}));
+      net.body.data.edges.update(net.body.data.edges.getIds().map(function(id) {{
+        return {{id:id, color: ce.indexOf(id)>=0 ? undefined : {{opacity:0.04}}}};
+      }}));
+    }}
+    function clearFocus() {{
+      focusedNode = null;
+      net.body.data.nodes.update(net.body.data.nodes.getIds().map(function(id) {{ return {{id:id,opacity:1.0}}; }}));
+      net.body.data.edges.update(net.body.data.edges.getIds().map(function(id) {{ return {{id:id,color:undefined}}; }}));
+    }}
+    net.on('click', function(p) {{
+      if (!focusMode) return;
+      if (p.nodes.length > 0) applyFocus(p.nodes[0]); else clearFocus();
+    }});
+    btnFocus.addEventListener('click', function() {{
+      focusMode = !focusMode;
+      btnFocus.classList.toggle('active', focusMode);
+      if (!focusMode) clearFocus();
+    }});
+
+    // Minimap
+    btnMinimap.addEventListener('click', function() {{
+      minimapOn = !minimapOn;
+      btnMinimap.classList.toggle('active', minimapOn);
+      minimapEl.style.display = minimapOn ? 'block' : 'none';
+      if (minimapOn && !minimapNet && window.vis && window.vis.Network) {{
+        var md = {{
+          nodes: new window.vis.DataSet(net.body.data.nodes.get()),
+          edges: new window.vis.DataSet(net.body.data.edges.get()),
+        }};
+        minimapNet = new window.vis.Network(minimapEl, md, {{
+          physics: false,
+          interaction: {{dragNodes:false,dragView:false,zoomView:false,selectable:false}},
+          nodes: {{shape:'dot',size:4,font:{{size:0}}}},
+          edges: {{arrows:{{to:false}},width:0.5}},
         }});
+        minimapNet.fit();
+        net.on('afterDrawing', function() {{ if (minimapNet) minimapNet.fit(); }});
       }}
     }});
 
-    // ── Tooltips ──────────────────────────────────────────────────────
-    net.on('hoverNode', function(params) {{
-      if (dragging) return;
-      var nodeId = params.node;
-      var html = nodeTips[nodeId];
-      if (html) showTip(html, params.event.clientX, params.event.clientY);
+    // PNG export
+    btnPng.addEventListener('click', function() {{
+      var c = document.querySelector('canvas');
+      if (!c) return;
+      var a = document.createElement('a');
+      a.download = 'cartographer_erd.png'; a.href = c.toDataURL('image/png'); a.click();
     }});
-    net.on('blurNode', hideTip);
 
-    net.on('hoverEdge', function(params) {{
-      if (dragging) return;
-      var edgeId = params.edge;
-      var html = edgeTips[edgeId];
-      if (html) showTip(html, params.event.clientX, params.event.clientY);
-    }});
-    net.on('blurEdge', hideTip);
-
-    // Update tooltip position on mouse move
+    // Tooltips
+    net.on('hoverNode', function(p) {{ if (!dragging) {{ var h=nodeTips[p.node]; if(h) showTip(h,p.event.clientX,p.event.clientY); }} }});
+    net.on('blurNode',  hideTip);
+    net.on('hoverEdge', function(p) {{ if (!dragging) {{ var h=edgeTips[p.edge]; if(h) showTip(h,p.event.clientX,p.event.clientY); }} }});
+    net.on('blurEdge',  hideTip);
     document.addEventListener('mousemove', function(e) {{
       if (dragging) {{ hideTip(); return; }}
-      if (tip.style.display === 'block') {{
-        var vw = window.innerWidth, vh = window.innerHeight;
-        var tw = 240, th = tip.offsetHeight || 180;
-        var left = e.clientX + 16;
-        var top  = e.clientY + 16;
-        if (left + tw > vw) left = e.clientX - tw - 8;
-        if (top  + th > vh) top  = e.clientY - th - 8;
-        tip.style.left = left + 'px';
-        tip.style.top  = top  + 'px';
+      if (tip.style.display==='block') {{
+        var vw=window.innerWidth,vh=window.innerHeight,tw=240,th=tip.offsetHeight||180;
+        var left=e.clientX+16,top=e.clientY+16;
+        if(left+tw>vw) left=e.clientX-tw-8; if(top+th>vh) top=e.clientY-th-8;
+        tip.style.left=left+'px'; tip.style.top=top+'px';
       }}
     }});
   }}, 100);
@@ -846,7 +962,6 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomExtends::after {{ cont
 </script>
 """
 
-    # Insert our overlay just before </body>
     raw_html = raw_html.replace("</body>", custom_js + "\n</body>")
     return raw_html
 
@@ -858,13 +973,13 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomExtends::after {{ cont
 if "dark_mode" not in st.session_state:
     st.session_state.dark_mode = True
 if "tables" not in st.session_state:
-    st.session_state.tables = {}          # name → pd.DataFrame
+    st.session_state.tables = {}
 if "schema_rels" not in st.session_state:
-    st.session_state.schema_rels = []     # from JSON/YAML schema
+    st.session_state.schema_rels = []
 if "manual_rels" not in st.session_state:
     st.session_state.manual_rels = []
 if "fk_cache" not in st.session_state:
-    st.session_state.fk_cache = {}        # digest → rels list
+    st.session_state.fk_cache = {}
 if "last_digest" not in st.session_state:
     st.session_state.last_digest = ""
 if "show_schema_ref" not in st.session_state:
@@ -881,17 +996,18 @@ if "db_schema_rels" not in st.session_state:
     st.session_state.db_schema_rels = []
 if "db_schema" not in st.session_state:
     st.session_state.db_schema = ""
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# Header
-# ═══════════════════════════════════════════════════════════════════════════
-
-# ── Theme state ─────────────────────────────────────────────────────────
-if "dark_mode" not in st.session_state:
-    st.session_state.dark_mode = True
-
-
+if "node_positions" not in st.session_state:
+    st.session_state.node_positions = {}
+if "false_positives" not in st.session_state:
+    st.session_state.false_positives = set()
+if "conf_overrides" not in st.session_state:
+    st.session_state.conf_overrides = {}
+if "erd_layout" not in st.session_state:
+    st.session_state.erd_layout = "force"
+if "erd_search" not in st.session_state:
+    st.session_state.erd_search = ""
+if "session_saved" not in st.session_state:
+    st.session_state.session_saved = None
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -899,7 +1015,6 @@ if "dark_mode" not in st.session_state:
 # ═══════════════════════════════════════════════════════════════════════════
 
 with st.sidebar:
-    # ── App title ────────────────────────────────────────────────────────
     st.markdown("""
 <div style="padding:4px 12px 0; font-family:'JetBrains Mono',monospace;">
   <div style="font-size:9px;letter-spacing:3px;color:var(--accent);text-transform:uppercase;
@@ -911,7 +1026,6 @@ with st.sidebar:
     Map relationships across any data source</div>
 </div>""", unsafe_allow_html=True)
 
-    # ── Theme toggle ─────────────────────────────────────────────────────
     st.markdown('<div style="height:6px;"></div>', unsafe_allow_html=True)
     toggle_label = "☀  Light mode" if st.session_state.dark_mode else "☾  Dark mode"
     if st.button(toggle_label, key="theme_btn", width='stretch'):
@@ -919,7 +1033,7 @@ with st.sidebar:
         st.rerun()
     st.markdown('<div style="height:4px;"></div>', unsafe_allow_html=True)
 
-    # ── 01 Upload CSVs ───────────────────────────────────────────────────
+    # ── 01 Upload Tables ─────────────────────────────────────────────────
     st.markdown('<div class="sidebar-section">01 // Upload Tables</div>', unsafe_allow_html=True)
     csv_files = st.file_uploader("Drop a file to begin mapping", type=["csv", "tsv", "xlsx", "xls", "xlsm", "ods", "parquet", "json", "ndjson", "sav", "por", "sas7bdat", "xpt", "rds", "rdata", "rda", "dta", "mat", "h5", "hdf5"], accept_multiple_files=True, key="csv_upload", label_visibility="collapsed")
 
@@ -941,7 +1055,6 @@ with st.sidebar:
                         df = xl.parse(sheets[0])
                         fmt = "xlsx"
                     else:
-                        # Multi-sheet: load each sheet as its own table
                         for sheet in sheets:
                             sdf = xl.parse(sheet)
                             sdf.columns = [re.sub(r"[^a-zA-Z0-9_]", "_", c) for c in sdf.columns]
@@ -1011,9 +1124,7 @@ with st.sidebar:
                         df = result[keys[0]]
                         fmt = ext
                     else:
-                        # Multi-object: load each as its own table
                         for key in keys:
-                            # .rds single-object files use None as key; skip in multi-object context
                             if key is None:
                                 continue
                             obj_df = result[key]
@@ -1041,7 +1152,6 @@ with st.sidebar:
                         df = pd.DataFrame(mat_vars[key])
                         fmt = "mat"
                     else:
-                        # Multi-variable: load each numeric/array variable as its own table
                         mat_loaded = 0
                         for key, val in mat_vars.items():
                             try:
@@ -1061,7 +1171,6 @@ with st.sidebar:
                 elif ext in ("h5", "hdf5"):
                     import h5py
                     raw_bytes = f.read()
-                    # Collect datasets recursively (handles data stored inside groups)
                     dataset_paths: list[str] = []
                     with h5py.File(io.BytesIO(raw_bytes), "r") as hf:
                         def _collect_datasets(name, obj):
@@ -1076,7 +1185,6 @@ with st.sidebar:
                             df = pd.DataFrame(hf[dataset_paths[0]][()])
                         fmt = ext
                     else:
-                        # Multi-dataset: load each as its own table
                         hdf_loaded = 0
                         with h5py.File(io.BytesIO(raw_bytes), "r") as hf:
                             for dpath in dataset_paths:
@@ -1085,7 +1193,6 @@ with st.sidebar:
                                 except Exception:
                                     continue
                                 obj_df.columns = [re.sub(r"[^a-zA-Z0-9_]", "_", str(c)) for c in obj_df.columns]
-                                # Use the dataset path as the table name suffix (replace / with _)
                                 safe_key = re.sub(r"[^a-zA-Z0-9_]", "_", dpath).strip("_") or f"ds{dataset_paths.index(dpath)}"
                                 oname = f"{tname}_{safe_key}"
                                 existed = oname in st.session_state.tables
@@ -1278,7 +1385,6 @@ with st.sidebar:
                 _db_connect("redshift", host=rs_host, port=rs_port, database=rs_db,
                             user=rs_user, password=rs_pwd, schema=rs_sch)
 
-    # ── Table picker shown after any successful connection ─────────────────
     if st.session_state.db_conn is not None and st.session_state.db_meta is not None:
         tables_list, pk_set, fk_map = st.session_state.db_meta
         table_labels = [f"{s}.{t}" for s, t in tables_list]
@@ -1370,7 +1476,7 @@ with st.sidebar:
             "format":        False, "distribution": False, "null_pattern": False,
         }
 
-    # ── 04 Manual Override ───────────────────────────────────────────────
+    # ── 05 Manual Override ───────────────────────────────────────────────
     st.markdown('<div class="sidebar-section">05 // Manual Override</div>', unsafe_allow_html=True)
     tnames = list(st.session_state.tables.keys())
 
@@ -1420,21 +1526,40 @@ else:
     pk_method = "both" if method == "manual" else method
     pk_map = {t: detect_pks(df, t, pk_method) for t, df in tables.items()}
 
-    # Compute FK rels (cached by digest that includes all detection params)
+    # ── Sampling for large tables (#11) ─────────────────────────────────
+    SAMPLE_THRESHOLD = 100_000
+    SAMPLE_SIZE      = 10_000
+    tables_for_analysis = {}
+    for _tn, _df in tables.items():
+        if len(_df) > SAMPLE_THRESHOLD:
+            _sdf = _df.sample(n=SAMPLE_SIZE, random_state=42).reset_index(drop=True)
+            _sdf.attrs = dict(_df.attrs)
+            _sdf.attrs["sampled"] = True
+            tables_for_analysis[_tn] = _sdf
+        else:
+            tables_for_analysis[_tn] = _df
+
+    # ── Lazy FK detection (#10) ───────────────────────────────────────────
     flags_key = json.dumps(enable_flags, sort_keys=True)
-    digest = table_digest(tables, f"{method}/{min_confidence}/{flags_key}/{st.session_state.get('dark_mode', True)}")
+    digest = table_digest(tables_for_analysis, f"{method}/{min_confidence}/{flags_key}")
     if digest not in st.session_state.fk_cache:
-        with st.spinner("Analysing tables…"):
-            auto_rels = detect_fks(
-                tables,
-                method=method,
-                min_confidence=min_confidence,
-                enable_flags=enable_flags,
-            )
+        prog = st.progress(0, text="Detecting relationships…")
+        auto_rels = detect_fks(
+            tables_for_analysis,
+            method=method,
+            min_confidence=min_confidence,
+            enable_flags=enable_flags,
+        )
+        prog.empty()
         st.session_state.fk_cache[digest] = auto_rels
         st.session_state.last_digest = digest
     else:
         auto_rels = st.session_state.fk_cache[digest]
+
+    # Propagate sampled flag back to original tables dict for node display
+    for _tn in tables_for_analysis:
+        if tables_for_analysis[_tn].attrs.get("sampled"):
+            tables[_tn].attrs["sampled"] = True
 
     # Merge: db constraints + schema > auto > manual
     _db_rels = st.session_state.get("db_schema_rels", [])
@@ -1446,46 +1571,108 @@ else:
     ]
     schema_pairs = {(r["from_table"], r["to_table"]) for r in _schema_plus_db}
     filtered_auto = [r for r in auto_rels if (r["from_table"], r["to_table"]) not in schema_pairs]
-    all_rels = _schema_plus_db + filtered_auto + st.session_state.manual_rels
+
+    # Apply false-positive suppression and confidence overrides
+    def _rel_key(r):
+        return (r["from_table"], r["from_col"], r.get("to_table",""), r.get("to_col",""))
+
+    _raw_rels = _schema_plus_db + filtered_auto + st.session_state.manual_rels
+    all_rels = []
+    for _r in _raw_rels:
+        _k = _rel_key(_r)
+        if _k in st.session_state.false_positives:
+            continue
+        if _k in st.session_state.conf_overrides:
+            _r = dict(_r, confidence=st.session_state.conf_overrides[_k])
+        all_rels.append(_r)
+
+    # ── Duplicate column detection (#3) ──────────────────────────────────
+    _all_cols: dict[str, list[str]] = {}
+    for _t, _df in tables.items():
+        for _c in _df.columns:
+            _all_cols.setdefault(_c, []).append(_t)
+    _dup_cols = {c: ts for c, ts in _all_cols.items() if len(ts) > 1}
+    _linked_pairs = {(r["from_table"], r["from_col"]) for r in all_rels}
+    _unlinked_dups = {
+        c: ts for c, ts in _dup_cols.items()
+        if not any((t, c) in _linked_pairs for t in ts)
+    }
 
     # ── Tabs ─────────────────────────────────────────────────────────────
-    tab_erd, tab_details, tab_rels = st.tabs(["ERD Diagram", "Table Details", "Relationships"])
+    tab_erd, tab_details, tab_rels, tab_export = st.tabs(["ERD Diagram", "Table Details", "Relationships", "Export"])
 
     # ─── ERD ─────────────────────────────────────────────────────────────
     with tab_erd:
-        erd_top_left, erd_top_right = st.columns([3, 1])
-        with erd_top_left:
+        ctl1, ctl2, ctl3, ctl4 = st.columns([2, 1, 1, 1])
+        with ctl1:
+            erd_search = st.text_input(
+                "Search tables", value=st.session_state.erd_search,
+                placeholder="Type a table name…", key="erd_search_input",
+                label_visibility="collapsed"
+            )
+            st.session_state.erd_search = erd_search
+        with ctl2:
+            layout_choice = st.selectbox(
+                "Layout", options=["force", "hierarchical", "circular"],
+                format_func=lambda x: {"force": "⬡ Force", "hierarchical": "⬇ Hierarchy", "circular": "◯ Circular"}[x],
+                index=["force","hierarchical","circular"].index(st.session_state.erd_layout),
+                key="erd_layout_select", label_visibility="collapsed"
+            )
+            st.session_state.erd_layout = layout_choice
+        with ctl3:
+            spring_length = st.slider(
+                "Spacing", min_value=80, max_value=600, value=220, step=20,
+                help="Node spacing (force layout only)", label_visibility="collapsed"
+            )
+        with ctl4:
             st.markdown("""
-            <div class="legend">
+            <div class="legend" style="padding:6px 0 0;">
               <div class="li"><div class="ld" style="background:#00e5a0;"></div>naming</div>
-              <div class="li"><div class="ld" style="background:#ff7b35;border-style:dashed;"></div>uniqueness (dashed)</div>
+              <div class="li"><div class="ld" style="background:#ff7b35;"></div>content</div>
               <div class="li"><div class="ld" style="background:#ff4d6d;"></div>manual</div>
               <div class="li"><div class="ld" style="background:#00d4ff;"></div>schema</div>
-            </div>
-            """, unsafe_allow_html=True)
-        with erd_top_right:
-            spring_length = st.slider(
-                "Node spacing",
-                min_value=80, max_value=600, value=220, step=20,
-                help="Increase to spread nodes further apart"
-            )
+            </div>""", unsafe_allow_html=True)
 
         try:
-            html = build_pyvis_html(tables, all_rels, pk_map, spring_length=spring_length, dark_mode=st.session_state.get('dark_mode', True))
-            st.components.v1.html(html, height=580, scrolling=False)
-            st.markdown('<div class="erd-hint">drag to move &amp; pin nodes · double-click to unpin · scroll to zoom · hover for details</div>', unsafe_allow_html=True)
+            html = build_pyvis_html(
+                tables, all_rels, pk_map,
+                spring_length=spring_length,
+                dark_mode=st.session_state.get("dark_mode", True),
+                saved_positions=st.session_state.get("node_positions", {}),
+                layout=st.session_state.erd_layout,
+                search=st.session_state.erd_search,
+            )
+            st.components.v1.html(html, height=640, scrolling=False)
+            st.markdown(
+                '<div class="erd-hint">drag · double-click to unpin · scroll to zoom · hover for details'
+                ' · <b>Focus</b> isolates a table · <b>Map</b> toggles minimap · <b>PNG↓</b> exports</div>',
+                unsafe_allow_html=True
+            )
         except Exception as e:
             st.error(f"ERD render error: {e}")
 
     # ─── Table Details ────────────────────────────────────────────────────
     with tab_details:
+        if _unlinked_dups:
+            dup_items = " · ".join(
+                f"<span style='color:var(--yellow);font-family:var(--mono);'>{c}</span>"
+                f"<span style='color:var(--text3);'> ({', '.join(ts)})</span>"
+                for c, ts in list(_unlinked_dups.items())[:8]
+            )
+            st.markdown(
+                f"<div style='background:rgba(251,191,36,0.08);border:1px solid rgba(251,191,36,0.25);"
+                f"border-radius:8px;padding:10px 14px;margin-bottom:14px;font-size:12px;"
+                f"font-family:var(--sans);color:var(--text2);'>"
+                f"<span style='color:var(--yellow);font-weight:600;'>⚠ Possible unlinked columns</span>"
+                f"&nbsp;&nbsp;{dup_items}</div>",
+                unsafe_allow_html=True
+            )
         for tname, df in tables.items():
             pks = pk_map.get(tname, [])
             fk_rels = [r for r in all_rels if r["from_table"] == tname]
             fk_cols = [r["from_col"] for r in fk_rels]
             src = df.attrs.get("source", "csv")
 
-            # Pills HTML
             pills = f'<span class="pill p-rows">{len(df):,} rows</span>' if len(df) > 0 else f'<span class="pill p-schema">schema only</span>'
             pills += f'<span class="pill p-cols">{len(df.columns)} cols</span>'
             pills += f'<span class="pill p-schema">{src}</span>'
@@ -1502,7 +1689,6 @@ else:
               <div style="margin-bottom:14px;">{pills}</div>
             </div>""", unsafe_allow_html=True)
 
-            # Column summary table
             if len(df) > 0:
                 summary = pd.DataFrame({
                     "Column": df.columns,
@@ -1513,7 +1699,6 @@ else:
                     "FK": ["✓" if c in fk_cols else "" for c in df.columns],
                 })
             else:
-                # Schema-only table — use column metadata if available
                 meta = df.attrs.get("columns_meta", [])
                 if meta:
                     summary = pd.DataFrame({
@@ -1535,6 +1720,12 @@ else:
                     })
 
             st.dataframe(summary, width='stretch', hide_index=True, height=min(len(summary) * 35 + 50, 320))
+
+            # Data preview (#2)
+            if len(df) > 0:
+                st.markdown('<div style="height:6px;"></div>', unsafe_allow_html=True)
+                if st.checkbox(f"Show preview — {tname}", key=f"prev_{tname}", value=False):
+                    st.dataframe(df.head(5), width='stretch', hide_index=True)
 
     # ─── Relationships ────────────────────────────────────────────────────
     with tab_rels:
@@ -1564,43 +1755,58 @@ else:
                     continue
                 st.markdown(f'<div class="rel-section">{label} ({len(sec_rels)})</div>', unsafe_allow_html=True)
                 for r in sec_rels:
-                    to_col   = r.get("to_col") or "?"
-                    conf     = r.get("confidence", "")
-                    score    = r.get("score", "")
-                    reasons  = r.get("reasons", [])
-                    signals  = r.get("signals", {})
+                    to_col  = r.get("to_col") or "?"
+                    conf    = r.get("confidence", "")
+                    score   = r.get("score", "")
+                    signals = r.get("signals", {})
+                    rk      = _rel_key(r)
 
-                    # Confidence block (only for auto-detected rels)
-                    if conf:
-                        score_str = f"{score:.0%}" if isinstance(score, float) else ""
-                        chips_html = "".join(
-                            f'<span class="sig-chip">{s.replace("_"," ")}</span>'
-                            for s in signals
-                        )
-                        conf_html = f"""<div class="conf-bar conf-{conf}">
-                          <div class="conf-dot"></div>
-                          <span class="conf-label">{conf}</span>
-                          <span class="conf-score">{score_str}</span>
-                        </div>"""
-                        chips_block = f'<div class="signal-chips">{chips_html}</div>' if chips_html else ""
-                    else:
-                        conf_html = ""
-                        chips_block = ""
+                    score_str  = f"{score:.0%}" if isinstance(score, float) else ""
+                    chips_html = "".join(f'<span class="sig-chip">{s.replace("_"," ")}</span>' for s in signals)
+                    conf_html  = (f"""<div class="conf-bar conf-{conf}">
+                      <div class="conf-dot"></div>
+                      <span class="conf-label">{conf}</span>
+                      <span class="conf-score">{score_str}</span>
+                    </div>""") if conf else ""
+                    chips_block = f'<div class="signal-chips">{chips_html}</div>' if chips_html else ""
 
-                    st.markdown(f"""<div class="rel-row" style="flex-wrap:wrap;">
-                      <span class="rt">{r["from_table"]}</span>
-                      <span class="rc">.{r["from_col"]}</span>
-                      <span class="ra">→</span>
-                      <span class="rt">{r["to_table"]}</span>
-                      <span class="rc">.{to_col}</span>
-                      <span class="rm {cls}">{key.replace("_"," ")}</span>
-                      {conf_html}
-                      {chips_block}
-                    </div>""", unsafe_allow_html=True)
+                    row_col, action_col = st.columns([8, 1])
+                    with row_col:
+                        st.markdown(f"""<div class="rel-row" style="flex-wrap:wrap;">
+                          <span class="rt">{r["from_table"]}</span>
+                          <span class="rc">.{r["from_col"]}</span>
+                          <span class="ra">→</span>
+                          <span class="rt">{r["to_table"]}</span>
+                          <span class="rc">.{to_col}</span>
+                          <span class="rm {cls}">{key.replace("_"," ")}</span>
+                          {conf_html}{chips_block}
+                        </div>""", unsafe_allow_html=True)
+                    with action_col:
+                        fp_key = f"fp_{hash(rk)}"
+                        if st.button("✕", key=fp_key, help="Mark as false positive"):
+                            st.session_state.false_positives.add(rk)
+                            st.rerun()
+                        if conf and key not in ("manual", "schema"):
+                            levels = ["low", "medium", "high"]
+                            cur_idx = levels.index(conf) if conf in levels else 1
+                            new_conf = st.selectbox(
+                                "conf", levels, index=cur_idx,
+                                key=f"co_{hash(rk)}", label_visibility="collapsed"
+                            )
+                            if new_conf != conf:
+                                st.session_state.conf_overrides[rk] = new_conf
+                                st.rerun()
 
         st.markdown('<div style="height:16px;"></div>', unsafe_allow_html=True)
 
-        # Export (include confidence + signals)
+        # False-positive management
+        if st.session_state.false_positives:
+            if st.button(f"↺  Restore {len(st.session_state.false_positives)} suppressed relationship(s)", key="restore_fp"):
+                st.session_state.false_positives = set()
+                st.session_state.conf_overrides  = {}
+                st.rerun()
+
+        # Export CSV (quick access)
         if all_rels:
             export_df = pd.DataFrame([{
                 "from_table":  r["from_table"],
@@ -1621,5 +1827,132 @@ else:
                 file_name="table_relationships.csv",
                 mime="text/csv",
             )
+
+    # ─── Export ──────────────────────────────────────────────────────────
+    with tab_export:
+        if not all_rels and not tables:
+            st.markdown('''<div class="empty-state"><div class="icon">⬇</div>
+              <h3>Nothing to export yet</h3></div>''', unsafe_allow_html=True)
+        else:
+            ex1, ex2, ex3 = st.tabs(["Relationships CSV", "dbt YAML", "Mermaid ERD"])
+
+            # ── CSV ───────────────────────────────────────────────────────
+            with ex1:
+                if all_rels:
+                    export_df = pd.DataFrame([{
+                        "from_table":  r["from_table"],  "from_col":   r["from_col"],
+                        "to_table":    r["to_table"],    "to_col":     r.get("to_col") or "",
+                        "detected_by": r["detected_by"], "confidence": r.get("confidence",""),
+                        "score":       r.get("score",""),
+                        "signals":     ", ".join(r.get("signals",{}).keys()),
+                        "reasons":     "; ".join(r.get("reasons",[])),
+                    } for r in all_rels])
+                    st.dataframe(export_df, width='stretch', hide_index=True)
+                    st.download_button("⬇  Download CSV", export_df.to_csv(index=False).encode(),
+                                       "table_relationships.csv", "text/csv")
+
+            # ── dbt YAML ──────────────────────────────────────────────────
+            with ex2:
+                st.markdown('''<div class="sidebar-hint">Generates a <code>schema.yml</code> with
+                  <code>relationships</code> tests for each detected FK. Drop it into your dbt
+                  models folder.</div>''', unsafe_allow_html=True)
+                dbt_models = {}
+                for r in all_rels:
+                    ft = r["from_table"]; fc = r["from_col"]
+                    tt = r["to_table"];   tc = r.get("to_col") or "id"
+                    dbt_models.setdefault(ft, {}).setdefault(fc, []).append((tt, tc))
+                dbt_lines = ["version: 2", "", "models:"]
+                for model, cols in dbt_models.items():
+                    dbt_lines += [f"  - name: {model}", "    columns:"]
+                    for col, targets in cols.items():
+                        dbt_lines += [f"      - name: {col}", "        tests:"]
+                        for (to_tbl, to_col) in targets:
+                            dbt_lines += [
+                                "          - relationships:",
+                                f"              to: ref('{to_tbl}')",
+                                f"              field: {to_col}",
+                            ]
+                    dbt_lines.append("")
+                dbt_yaml = "\n".join(dbt_lines)
+                st.code(dbt_yaml, language="yaml")
+                st.download_button("⬇  Download schema.yml", dbt_yaml.encode(),
+                                   "schema.yml", "text/yaml")
+
+            # ── Mermaid ───────────────────────────────────────────────────
+            with ex3:
+                st.markdown('''<div class="sidebar-hint">Paste into any Markdown file, GitHub README,
+                  Notion, or Confluence to render the ERD inline.</div>''', unsafe_allow_html=True)
+                mermaid_lines = ["erDiagram"]
+                seen_entities = set()
+                for tname, df in tables.items():
+                    pks = pk_map.get(tname, [])
+                    cols = list(df.columns)
+                    mermaid_lines.append(f"  {tname} {{")
+                    for c in cols[:20]:
+                        dtype = str(df[c].dtype) if len(df) > 0 else "string"
+                        dtype = dtype.replace("int64","int").replace("float64","float").replace("object","string")
+                        pk_tag = " PK" if c in pks else ""
+                        mermaid_lines.append(f"    {dtype} {c}{pk_tag}")
+                    if len(cols) > 20:
+                        mermaid_lines.append(f"    string _and_{len(cols)-20}_more")
+                    mermaid_lines.append("  }")
+                    seen_entities.add(tname)
+                for r in all_rels:
+                    ft = r["from_table"]; tt = r["to_table"]
+                    fc = r["from_col"];   tc = r.get("to_col") or "id"
+                    if ft in seen_entities and tt in seen_entities:
+                        mermaid_lines.append(f"  {ft} ||--o{{ {tt} : \"{fc} → {tc}\"")
+                mermaid_text = "\n".join(mermaid_lines)
+                st.code(mermaid_text, language="text")
+                st.download_button("⬇  Download .mmd", mermaid_text.encode(),
+                                   "cartographer_erd.mmd", "text/plain")
+
+        st.markdown("---")
+        st.markdown('<div class="sidebar-section">Session</div>', unsafe_allow_html=True)
+        sc1, sc2 = st.columns(2)
+        with sc1:
+            if st.button("💾  Save session", key="save_session", width="stretch"):
+                session_data = {
+                    "tables":         {k: v.to_dict(orient="records") for k, v in tables.items()},
+                    "table_attrs":    {k: dict(v.attrs) for k, v in tables.items()},
+                    "table_cols":     {k: list(v.columns) for k, v in tables.items()},
+                    "schema_rels":    st.session_state.schema_rels,
+                    "manual_rels":    st.session_state.manual_rels,
+                    "node_positions": st.session_state.node_positions,
+                    "false_positives":list(st.session_state.false_positives),
+                    "conf_overrides": {str(k): v for k, v in st.session_state.conf_overrides.items()},
+                    "dark_mode":      st.session_state.dark_mode,
+                }
+                session_json = json.dumps(session_data, default=str)
+                st.download_button("⬇  Download session.json", session_json.encode(),
+                                   "cartographer_session.json", "application/json",
+                                   key="dl_session")
+        with sc2:
+            session_upload = st.file_uploader("Restore session", type=["json"],
+                                              key="session_restore_upload",
+                                              label_visibility="collapsed")
+            if session_upload:
+                try:
+                    sd = json.loads(session_upload.read().decode())
+                    restored = {}
+                    for tname, records in sd["tables"].items():
+                        cols = sd["table_cols"][tname]
+                        df_r = pd.DataFrame(records, columns=cols)
+                        attrs = sd.get("table_attrs", {}).get(tname, {})
+                        for ak, av in attrs.items():
+                            df_r.attrs[ak] = av
+                        restored[tname] = df_r
+                    st.session_state.tables         = restored
+                    st.session_state.schema_rels    = sd.get("schema_rels", [])
+                    st.session_state.manual_rels    = sd.get("manual_rels", [])
+                    st.session_state.node_positions = sd.get("node_positions", {})
+                    st.session_state.false_positives= set(tuple(x) for x in sd.get("false_positives", []))
+                    st.session_state.conf_overrides = {eval(k): v for k, v in sd.get("conf_overrides", {}).items()}
+                    st.session_state.dark_mode      = sd.get("dark_mode", True)
+                    st.session_state.fk_cache       = {}
+                    st.success("Session restored!")
+                    st.rerun()
+                except Exception as e:
+                    st.error(f"Restore failed: {e}")
 
 st.markdown('</div>', unsafe_allow_html=True)


### PR DESCRIPTION
Pull request · MD
Copy

# PR: Cartographer — ERD Visualization Overhaul + Feature Expansion

## Summary

This PR represents two major development pushes against `app.py`, followed by minor polish fixes. In aggregate, they transform Cartographer from a functional prototype into a production-quality data documentation tool. The first push overhauled the vis.js ERD diagram with 9 interactive improvements. The second added 11 new features across schema quality, export, performance, and workflow. A follow-up patch addressed Streamlit API deprecations and a widget rendering bug.

---

## Part 1 — ERD Visualization Overhaul

The `build_pyvis_html()` function was substantially rewritten to deliver a richer, more interactive diagram experience. All changes are self-contained within the HTML/JS injected into the vis.js iframe.

### 1. Column list inside table nodes
Each node now renders the full column list below the table name, separated by a Unicode rule line. Columns are prefixed with a 🔑 icon for primary keys, ↗ for foreign keys, and · for plain columns. Long tables are capped at 12 visible columns with a `… +N more` indicator.

### 2. Hover-revealed edge labels (progressive disclosure)
Edge labels are hidden by default to reduce visual noise at scale. A rich tooltip appears on hover, showing the full `from_table.from_col → to_table.to_col` path, the detection method (color-coded), confidence level, score, and contributing signal reasons.

### 3. Cardinality notation
Every edge carries explicit 1-to-many notation: a vertical bar (`|`) at the "one" end and a standard arrow at the "many" end, using vis.js's built-in `bar` and `arrow` types.

### 4. Minimap overlay
A "Map" toolbar button toggles a 140×90px minimap in the bottom-right corner of the ERD canvas. It renders a scaled-down dot representation of the full graph using a secondary vis.js Network instance and re-fits on every `afterDrawing` event.

### 5. Source-cluster background bubbles
When tables originate from more than one source (e.g. CSV + PostgreSQL), an HTML5 Canvas overlay draws translucent ellipses around each source group, with a faint source label. The overlay redraws on zoom, pan, and drag to stay aligned with the main canvas.

### 6. Confidence-based edge opacity
Edge opacity is driven by relationship confidence: `high → 0.95`, `medium → 0.60`, `low → 0.30`. Uncertain relationships visually recede without disappearing.

### 7. Persistent node positioning
After a node is dragged, its position is pinned (`fixed: {x: true, y: true}`) and the full position map is broadcast to the parent Streamlit frame via `window.parent.postMessage`. Streamlit captures this in `st.session_state.node_positions` and passes it back on the next render, so layout survives page refreshes. Double-clicking a node releases its pin.

### 8. Focus mode
A "Focus" toolbar button enables click-to-isolate behavior. Clicking a node dims all non-connected nodes to 12% opacity and all non-connected edges to 4% opacity. Clicking the background clears the focus.

### 9. PNG export
A "PNG ↓" toolbar button reads the vis.js canvas via `toDataURL('image/png')` and triggers a browser download as `cartographer_erd.png`.

### Supporting changes
- Navigation button CSS replaced with Unicode characters (↑ ↓ ← → + − ⊡) to eliminate the default sprite-sheet icons.
- Custom tooltip positioned via `clientX/Y` with viewport edge detection to prevent overflow.
- `build_pyvis_html()` signature extended with `saved_positions: dict | None`.
- New `node_positions` key added to session state initialisation.

---

## Part 2 — 11-Feature Expansion

A second pass implementing the full feature roadmap recommended after the visualization overhaul.

### New helpers

**`_save_session() → bytes`**
Serialises the entire workspace — tables (base64-encoded CSV), schema/manual relationships, node positions, and relationship confidence overrides — to a JSON blob for download. Tables store `sampled`, `original_rows`, and `source` metadata so they restore faithfully.

**`_load_session(raw: bytes) → None`**
Deserialises a saved workspace blob back into session state, including confidence override tuples, and clears the FK cache to force re-detection.

**`_generate_dbt_yaml(tables, rels, pk_map) → str`**
Generates a valid `schema.yml` for dbt. PK columns receive `unique` and `not_null` tests; FK columns receive a `relationships` test pointing to `ref('target_table')` with the target field. Output is clean PyYAML with `sort_keys=False`.

**`_generate_mermaid(tables, rels, pk_map) → str`**
Generates a Mermaid `erDiagram` block. Each entity lists all columns with sanitised dtype names and PK markers. Relationships use `||--o{` notation with the FK column name as the label.

**`_find_duplicate_columns(tables, rels) → list[dict]`**
Scans all tables for column names that appear in two or more tables but are not yet linked by any relationship. Returns a list of `{column, tables}` dicts. Already-linked columns are excluded to avoid false positives.

### New constants

```python
SAMPLE_THRESHOLD = 100_000  # rows — triggers sampling on upload
SAMPLE_SIZE      = 10_000   # target sample size
```

### New session state keys

| Key | Type | Purpose |
|---|---|---|
| `rel_overrides` | `dict[tuple, str]` | Confidence overrides keyed by `(from_table, from_col, to_table, to_col)` |
| `fk_needs_run` | `bool` | Lazy FK detection flag — set on upload, cleared after first run |

### ERD tab — layout presets & search

**Layout presets** — a new selectbox offers four modes:
- **Force** (default) — existing forceAtlas2Based physics
- **Hierarchical** — vis.js hierarchical layout, `direction: UD`, physics disabled
- **Circular** — force layout, then post-stabilization JS arranges nodes in a ring at `radius = max(200, n * 60px)`
- **Compact** — forceAtlas2Based with tighter constants (`springLength: 80`, `centralGravity: 0.02`)

Saved positions are only restored in `force` mode; the other modes always recompute.

**Table search box** — a text input above the ERD. Matching node names receive a 3px `#fbbf24` border and the camera zooms to them; non-matching nodes drop to 25% opacity.

**Edge thickness by confidence** — `conf_style` maps confidence to `(opacity, width)`:

| Confidence | Opacity | Width |
|---|---|---|
| high | 0.95 | 3.0px |
| medium | 0.60 | 1.5px |
| low | 0.30 | 0.8px |

Combining opacity and thickness gives a two-channel confidence signal.

### Table Details tab — previews & warnings

**Data preview** — after the column summary dataframe, a checkbox reveals a 5-row data preview. Uses `st.checkbox` instead of `st.expander` to avoid a Streamlit rendering bug where the collapse icon name (`arrow_right`) leaked as literal text.

**Duplicate column warnings** — above each table card, if `_find_duplicate_columns()` finds unlinked shared column names a yellow warning banner lists them as potential missed relationships.

**Sampled table banner** — tables auto-sampled on upload display a `⚠ SAMPLED N of M rows` banner and include a note in the hover tooltip.

### Relationships tab — confidence editing

Each auto-detected relationship row gains inline confidence controls:
- **▲ Promote** — forces confidence to `high`
- **▼ Demote** — forces confidence to `low`
- **✕ Suppress** — hides the relationship from the ERD and all exports

Edits are stored in `st.session_state.rel_overrides` as `(from_table, from_col, to_table, to_col) → new_confidence`. Suppressed rows render with `.rel-row.suppressed` CSS (dashed border, 40% opacity). A "Clear overrides" button resets all edits. Overrides survive session save/restore.

### Export tab — new export formats

Three additional download buttons alongside the existing CSV export:

- **dbt schema.yml** — calls `_generate_dbt_yaml()`, downloads as `schema.yml`
- **Mermaid ERD** — calls `_generate_mermaid()`, downloads as `erd.mmd`
- **Save session** — calls `_save_session()`, downloads as `cartographer_session.json`

A **Restore session** file uploader calls `_load_session()` and triggers `st.rerun()`.

### Large table sampling

On file upload, each DataFrame is checked against `SAMPLE_THRESHOLD` (100k rows). If exceeded, a random 10k-row sample is taken via `df.sample(SAMPLE_SIZE, random_state=42)`. The original row count is stored in `df.attrs["original_rows"]` and `df.attrs["sampled"] = True`. The full table is never held in session state.

### Lazy FK detection

FK detection no longer runs automatically on file upload. Uploads set `st.session_state.fk_needs_run = True`. Detection runs only when the user navigates to the ERD or Relationships tab, guarded by `if st.session_state.fk_needs_run`. A spinner shows `"Analysing relationships…"`. After the first run the flag is cleared and results are cached as before.

---

## Part 3 — Polish & Bug Fixes

### Streamlit API deprecation fix
Replaced all `use_container_width=True` on `st.dataframe()` calls with `width='stretch'`. Eliminates ~20 deprecation warnings emitted on every page load.

### `arrow_right` rendering bug
`st.expander` on this Streamlit build emits the collapse arrow's Material icon name as literal text. Replaced the Table Details preview expander with `st.checkbox`.

### Layout spacing
Added a 6px spacer between the column summary dataframe and the preview toggle to prevent visual cramping at the bottom of each table card.

---

## Files changed

| File | Change |
|---|---|
| `app.py` | All changes — ~1,950 lines |

No changes to `inference.py`, `schema_parser.py`, `db_connectors.py`, or any supporting module.

---

## Testing checklist

- [ ] Upload 2+ CSV files — ERD renders with column list in nodes, cardinality arrows, cluster bubbles
- [ ] Drag nodes — positions persist on next rerun
- [ ] Focus mode — click a node, verify neighbours highlighted, others dimmed
- [ ] Minimap — toggles on/off, stays in sync with main canvas
- [ ] PNG export — downloads `cartographer_erd.png`
- [ ] Layout presets — all four modes render; circular arranges in a ring; hierarchical shows top-down tree
- [ ] Table search — matching nodes highlighted, non-matching dimmed, camera zooms to matches
- [ ] Data preview checkbox — shows 5 rows, no `arrow_right` text visible
- [ ] Duplicate column warning — appears when two unlinked tables share a column name
- [ ] Confidence editing — promote/demote/suppress updates the row styling and the ERD
- [ ] dbt export — valid YAML with `unique`, `not_null`, and `relationships` tests
- [ ] Mermaid export — valid `erDiagram` block (verify at mermaid.live)
- [ ] Session save/restore — download `.json`, reload page, upload file, workspace restored
- [ ] Large table sampling — upload a file >100k rows, verify sampled banner in Table Details
- [ ] No `use_container_width` deprecation warnings in terminal